### PR TITLE
Wrapped fields in higher-order components

### DIFF
--- a/src/fields/Input.jsx
+++ b/src/fields/Input.jsx
@@ -1,5 +1,5 @@
-
 import Input from '../elements/Input';
 import fieldHoc from '../add-ons/field-hoc';
+import validatedFieldHoc from '../add-ons/validated-field-hoc';
 
-export default fieldHoc(Input);
+export default validatedFieldHoc(fieldHoc(Input));

--- a/src/fields/RadioGroup.jsx
+++ b/src/fields/RadioGroup.jsx
@@ -1,6 +1,6 @@
-
 import radioGroupHoc from '../add-ons/radio-group-hoc';
 import fieldHoc from '../add-ons/field-hoc';
 import Radio from '../elements/Radio';
+import validatedFieldHoc from '../add-ons/validated-field-hoc';
 
-export default fieldHoc(radioGroupHoc(Radio));
+export default validatedFieldHoc(fieldHoc(radioGroupHoc(Radio)));

--- a/src/fields/Select.jsx
+++ b/src/fields/Select.jsx
@@ -1,6 +1,5 @@
-
-
 import Select from '../elements/Select';
 import fieldHoc from '../add-ons/field-hoc';
+import validatedFieldHoc from '../add-ons/validated-field-hoc';
 
-export default fieldHoc(Select);
+export default validatedFieldHoc(fieldHoc(Select));

--- a/src/fields/Textarea.jsx
+++ b/src/fields/Textarea.jsx
@@ -1,5 +1,5 @@
-
 import Textarea from '../elements/Textarea';
 import fieldHoc from '../add-ons/field-hoc';
+import validatedFieldHoc from '../add-ons/validated-field-hoc';
 
-export default fieldHoc(Textarea);
+export default validatedFieldHoc(fieldHoc(Textarea));

--- a/src/whatever/Input.jsx
+++ b/src/whatever/Input.jsx
@@ -1,4 +1,0 @@
-import Input from '../fields/Input';
-import ValidatedField from '../add-ons/validated-field-hoc';
-
-export default ValidatedField(Input);

--- a/src/whatever/Select.jsx
+++ b/src/whatever/Select.jsx
@@ -1,4 +1,0 @@
-import Select from '../fields/Select';
-import ValidatedField from '../add-ons/validated-field-hoc';
-
-export default ValidatedField(Select);

--- a/src/whatever/Textarea.jsx
+++ b/src/whatever/Textarea.jsx
@@ -1,4 +1,0 @@
-import Textarea from '../fields/Textarea';
-import ValidatedField from '../add-ons/validated-field-hoc';
-
-export default ValidatedField(Textarea);


### PR DESCRIPTION
Wrapped fields in HOCs and removed 'whatever' folder that contained tentative validated field components. Index.js now exports validated field components.
